### PR TITLE
ci: fix ERR_OSSL_EVP_UNSUPPORTED

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [16.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,6 +35,8 @@ jobs:
         run: yarn install
 
       - name: Build
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
         run: |
           yarn export
           touch out/.nojekyll


### PR DESCRIPTION
fix ERR_OSSL_EVP_UNSUPPORTED by using Node 16 + openssl-legacy-provider